### PR TITLE
RVM config files added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+.rvmrc
+.ruby-version


### PR DESCRIPTION
Added .rvmrc and .ruby-version to .gitignore, so that developers can have different setup for ruby version and gem management.
